### PR TITLE
Refactor logging system: Replace --quiet with --verbose flag

### DIFF
--- a/modules/utils.py
+++ b/modules/utils.py
@@ -3,10 +3,16 @@ import logging
 import csv
 from datetime import datetime
 
-def setup_logging(quiet=False, filename_prefix="plutils"):
+def setup_logging(verbose=False, filename_prefix="plutils"):
     """
     Set up logging to file and console. Returns the log file name.
     Log files are stored in the "logs" subdirectory.
+    By default, console logging is suppressed (only critical messages are shown).
+    Use the verbose flag to enable screen logging.
+    
+    :param verbose: Boolean flag to enable console logging.
+    :param filename_prefix: Prefix for the log file name.
+    :return: The generated log file name.
     """
     # Ensure the logs directory exists.
     logs_dir = "logs"
@@ -18,16 +24,16 @@ def setup_logging(quiet=False, filename_prefix="plutils"):
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)
     
-    # File handler
+    # File handler (always active)
     fh = logging.FileHandler(logfile)
     fh.setLevel(logging.INFO)
     
-    # Console handler
+    # Console handler: enable if verbose, otherwise suppress (only critical messages)
     ch = logging.StreamHandler()
-    if quiet:
-        ch.setLevel(logging.CRITICAL)
-    else:
+    if verbose:
         ch.setLevel(logging.INFO)
+    else:
+        ch.setLevel(logging.CRITICAL)
     
     formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
     fh.setFormatter(formatter)
@@ -43,6 +49,10 @@ def write_csv_report(csv_filename, header, data_rows):
     """
     Write a CSV report with the given header and data rows.
     Reports are stored in the "reports" subdirectory.
+    
+    :param csv_filename: Output CSV file name.
+    :param header: List of column headers.
+    :param data_rows: List of data rows (each row is a list).
     """
     # Ensure the reports directory exists.
     reports_dir = "reports"

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,52 @@
+import unittest
+import logging
+from modules.utils import setup_logging
+
+class TestLoggingSetup(unittest.TestCase):
+    def setUp(self):
+        # Clear all existing handlers before each test.
+        logger = logging.getLogger()
+        for handler in logger.handlers[:]:
+            logger.removeHandler(handler)
+            try:
+                handler.close()
+            except Exception:
+                pass
+
+    def tearDown(self):
+        # Close all handlers after each test.
+        logger = logging.getLogger()
+        for handler in logger.handlers[:]:
+            logger.removeHandler(handler)
+            try:
+                handler.close()
+            except Exception:
+                pass
+
+    def test_setup_logging_verbose(self):
+        # When verbose is True, console logging should be enabled (INFO level)
+        logfile = setup_logging(verbose=True, filename_prefix="test_verbose")
+        # Filter for console handlers (exclude FileHandlers)
+        stream_handlers = [
+            h for h in logging.getLogger().handlers 
+            if hasattr(h, "stream") and not isinstance(h, logging.FileHandler)
+        ]
+        self.assertTrue(stream_handlers, "No console stream handler found")
+        for handler in stream_handlers:
+            self.assertEqual(handler.level, logging.INFO, "Console handler level should be INFO when verbose is True")
+
+    def test_setup_logging_non_verbose(self):
+        # When verbose is False, console logging should be suppressed (CRITICAL level)
+        logfile = setup_logging(verbose=False, filename_prefix="test_nonverbose")
+        # Filter for console handlers (exclude FileHandlers)
+        stream_handlers = [
+            h for h in logging.getLogger().handlers 
+            if hasattr(h, "stream") and not isinstance(h, logging.FileHandler)
+        ]
+        self.assertTrue(stream_handlers, "No console stream handler found")
+        for handler in stream_handlers:
+            self.assertEqual(handler.level, logging.CRITICAL, "Console handler level should be CRITICAL when verbose is False")
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
### Summary
This PR updates the logging behavior across the AWS Prefix List Utilities tool.

### Key Changes:
- The default behavior now suppresses console logging (only critical messages are shown).
- Introduced a new `-v`/`--verbose` flag to enable detailed console logging.
- Removed the `--quiet` option and updated all relevant help messages and documentation.
- Logs are now consistently written to a `logs/` directory.
- CSV reports are stored in the `reports/` directory.
- Fixed unit tests in `tests/test_logging.py` by ensuring logging handlers are properly closed, preventing ResourceWarnings.

These changes improve the clarity of output, making it easier for users to control logging levels while maintaining clean directory structures for logs and reports.
